### PR TITLE
Add Promise-sync mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -232,9 +232,9 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.50",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
-      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "version": "0.10.51",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
+      "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
@@ -262,15 +262,27 @@
         "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "~0.3.5"
+      },
+      "dependencies": {
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "dev": true,
+          "requires": {
+            "d": "1",
+            "es5-ext": "~0.10.14"
+          }
+        }
       }
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
+      "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.51"
       }
     },
     "es6-weak-map": {
@@ -415,6 +427,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "isarray": {
       "version": "0.0.1",
@@ -654,11 +671,12 @@
       }
     },
     "phpcore": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/phpcore/-/phpcore-5.8.1.tgz",
-      "integrity": "sha512-qNnxjz4dwkU3xdxKRJUuJRlzwBVFpN6y+ga6iCkphCxan1keHHxQ57hLM/9RqKjY4TJ9e+c2MB+9RSCUIcbs6A==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/phpcore/-/phpcore-5.9.0.tgz",
+      "integrity": "sha512-gGefcMZVMHISJnu+SdP4hj58C5ULlnYLYg+vp8/AzbzHDEQd8kKw+hIOBtaBnMSdDNkii/gQbbJLIpvlDozELg==",
       "requires": {
         "es6-weak-map": "^2.0.3",
+        "is-promise": "^2.1.0",
         "lie": "^3.0.1",
         "microdash": "~1",
         "pausable": "~4",
@@ -690,9 +708,9 @@
       }
     },
     "phptojs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/phptojs/-/phptojs-7.0.0.tgz",
-      "integrity": "sha512-TFDF3lSdHgsofrVSu8qX8FydVX/6iD2oJMBvTgOzhseDtQ66yJ7dBpq25VAWz+oDFLBpT/JmztHWrZw93rZDtQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/phptojs/-/phptojs-7.1.0.tgz",
+      "integrity": "sha512-xTvtRaf/sehpry5G4vvnrCoSPXBEHSnH/B5uRcOP7DoSRTKl5jnI/6+LxcFKNIPZfp92KRcNbA4+PlVa+mlGCQ==",
       "dev": true,
       "requires": {
         "es6-set": "^0.1.5",
@@ -703,16 +721,6 @@
         "transpiler": "~1.2"
       },
       "dependencies": {
-        "phpcommon": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/phpcommon/-/phpcommon-1.13.0.tgz",
-          "integrity": "sha512-gPBLulAOD0seWGPnqrLgZsNv4u5TosPtdTPQu6oquHLR4VelV2ydV1W6sX76VEkARvs3aOm0ohcLGegQ8Pi1bg==",
-          "dev": true,
-          "requires": {
-            "microdash": "~1",
-            "template-string": "~1"
-          }
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -826,9 +834,9 @@
       }
     },
     "type": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "microdash": "~1",
     "phpcommon": "^1.13.0",
-    "phpcore": "^5.8.1"
+    "phpcore": "^5.9.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -34,7 +34,7 @@
     "mocha": "^5.2.0",
     "nowdoc": "^1.0.1",
     "phptoast": "^7.0.0",
-    "phptojs": "^7.0.0",
+    "phptojs": "^7.1.0",
     "sinon": "^5.1.1",
     "sinon-chai": "^3.3.0"
   },

--- a/psync.js
+++ b/psync.js
@@ -8,13 +8,16 @@
  */
 
 /**
- * Asynchronous (async) mode entrypoint
+ * "Promise-synchronous" (psync) mode entrypoint
+ *
+ * Allows the public API to be Promise-based even when not using Pausable,
+ * so that switching to/from async mode does not require changes to the consuming application.
  */
 
 'use strict';
 
 var builtins = require('./src/builtin/builtins'),
-    runtime = require('phpcore/async');
+    runtime = require('phpcore/psync');
 
 runtime.install(builtins);
 

--- a/sync.js
+++ b/sync.js
@@ -7,6 +7,10 @@
  * https://github.com/uniter/phpruntime/raw/master/MIT-LICENSE.txt
  */
 
+/**
+ * Synchronous (sync) mode entrypoint
+ */
+
 'use strict';
 
 var builtins = require('./src/builtin/builtins'),

--- a/test/integration/tools.js
+++ b/test/integration/tools.js
@@ -49,7 +49,8 @@ module.exports = {
             Engine,
             AsyncPHPState,
             phpCommon,
-            pausable
+            pausable,
+            'async'
         );
 
         // Install the standard set of builtins
@@ -65,7 +66,8 @@ module.exports = {
             Engine,
             SyncPHPState,
             phpCommon,
-            null // Don't make Pausable available - running synchronously
+            null, // Don't make Pausable available - running synchronously
+            'sync'
         );
 
         // Install the standard set of builtins

--- a/test/unit/builtin/functions/variableHandling/var_exportTest.js
+++ b/test/unit/builtin/functions/variableHandling/var_exportTest.js
@@ -26,7 +26,7 @@ describe('PHP "var_export" builtin function', function () {
     beforeEach(function () {
         this.callStack = sinon.createStubInstance(CallStack);
         this.output = sinon.createStubInstance(Output);
-        this.valueFactory = new ValueFactory(null, this.callStack);
+        this.valueFactory = new ValueFactory(null, 'sync', this.callStack);
         this.internals = {
             callStack: this.callStack,
             output: this.output,


### PR DESCRIPTION
This change allows a consistent public API across async mode and (p)sync modes. Previously, the consuming application needed to deal with either a Promise (as returned in async mode) or the resulting Value object. This additional effort made it more likely that only one of the options would be supported, meaning that switching between modes (eg. to enable the experimental debugger) would involve code changes.

Also see:

PHPToJS PR: uniter/phptojs#4
PHPCore PR: uniter/phpcore#3
PHPify PR: uniter/phpify#2